### PR TITLE
Correct online count

### DIFF
--- a/cogs/lobby.py
+++ b/cogs/lobby.py
@@ -1,6 +1,6 @@
 from models.Player import Player
 from discord.ext import commands, tasks
-from discord import VoiceChannel
+from discord import VoiceChannel, Status
 import discord
 from datetime import datetime
 import random
@@ -90,8 +90,9 @@ class Lobby(commands.Cog):
             voiceCount += len(channel.members)
                 
         onlineCount = 0
-        for members in ctx.message.guild.members:
-          if (not(members.bot)):
+        for member in ctx.message.guild.members:
+          print(member.name, member.bot, member.status)
+          if (not(member.bot) and member.status == Status.online):
             onlineCount += 1
 
         if (voiceCount >= 8):


### PR DESCRIPTION
Check `.status` against `Status.online`. Tested in Super Cash Bros.