### PR TITLE
Support Broadcast Definitions in Channel Topic

### DIFF
--- a/models/Player.py
+++ b/models/Player.py
@@ -14,8 +14,11 @@ class Player():
 
     def getName(self):
         if self.member.display_name == None:
-            return ''
+          return ''
         return self.member.display_name
+    
+    def getMention(self):
+        return self.member.mention
 
     def setType(self, player_type: str):
         self.player_type = player_type


### PR DESCRIPTION
This implements a desired function that was not currently working. When a lobby reaches 7 players, spam one (or more) specific channels with an invite. 

```
#l4d2 channel topi:

?help for more information - Message if you have suggestions

?broadcast #video_games
```

![image](https://user-images.githubusercontent.com/3579057/89091559-72d2e880-d35f-11ea-9601-40c4c5fd62a9.png)
