### PR TITLE
Fix Bug in Reset Code

### DIFF
--- a/cogs/LobbyCommands.py
+++ b/cogs/LobbyCommands.py
@@ -107,12 +107,13 @@ class LobbyCommands(commands.Cog):
         resetRangeEnd = datetime.time(13, 1)
         if resetRangeStart <= now <= resetRangeEnd:
           daily_fact = self.getTodaysUselessFact()
-          for lobby in self.lobbies:
-            self.lobbies[lobby.channel.id] = Lobby(lobby.channel, self.bot)
+          for index in self.lobbies:
+            channel = self.lobbies[index].channel
+            self.lobbies[index] = Lobby(channel, self.bot)
             embed = discord.Embed(colour = discord.Colour.orange())
             embed.set_author(name=f'Daily Update - {str(datetime.date.today())}')
             embed.add_field(name='Lobby has been cleared!', value=daily_fact, inline=False)
-            await lobby.channel.send(embed=embed)
+            await channel.send(embed=embed)
 
     def getTodaysUselessFact(self):
         req = urllib.request.urlopen('https://uselessfacts.jsph.pl/today.json?language=en')


### PR DESCRIPTION
This code was hitting an exception
```
Aug 08 13:00:58 localhost python[805487]: ERROR:discord.ext.tasks:Internal background task failed.
Aug 08 13:00:58 localhost python[805487]: Traceback (most recent call last):
Aug 08 13:00:58 localhost python[805487]:   File "/home/jd/.local/lib/python3.8/site-packages/discord/ext/tasks/__init__.py", line 73, in _loop
Aug 08 13:00:58 localhost python[805487]:     await self.coro(*args, **kwargs)
Aug 08 13:00:58 localhost python[805487]:   File "/home/jd/lfd2-bot/cogs/LobbyCommands.py", line 111, in janitor
Aug 08 13:00:58 localhost python[805487]:     self.lobbies[lobby.channel.id] = Lobby(lobby.channel, self.bot)
Aug 08 13:00:58 localhost python[805487]: AttributeError: 'int' object has no attribute 'channel'
```

Python for..in loops iterate on keys when the iterable is a dictionary. Of course an integer does not have the member 'channel' (or any member for that matter). This is something any good language would tell you with static analysis. 

I didn't test this because we don't have any tests and the manual setup is annoying. Based on the error timestamp, I'm confident this will fire at the right time. If this doesn't work in the future it will be because of an exception and I can fix it again. 