### PR TITLE
[RFC] Allow Adding Players who haven't Left Before

### DIFF
--- a/cogs/LobbyCommands.py
+++ b/cogs/LobbyCommands.py
@@ -57,7 +57,7 @@ class LobbyCommands(Cog):
         if ctx.channel.id in self.lobbies:
           raise UsageException(ctx.channel, 'The lobby has already been started. You can restart the lobby with `?reset`.')
 
-        self.lobbies[ctx.c(hannel.id] = Lobby(self.bot, ctx.channel)
+        self.lobbies[ctx.channel.id] = Lobby(self.bot, ctx.channel)
         await ctx.send('The lobby has been started!')
 
     @command()

--- a/cogs/LobbyCommands.py
+++ b/cogs/LobbyCommands.py
@@ -65,13 +65,17 @@ class LobbyCommands(commands.Cog):
         await self.getLobbyThen(ctx, lambda lobby: lobby.add(ctx.author))
 
     @commands.command()
+    async def add(self, ctx, member: discord.Member):
+        await self.getLobbyThen(ctx, lambda lobby: lobby.add(member, author=ctx.author))
+
+    @commands.command()
     async def leave(self, ctx):
         await self.getLobbyThen(ctx, lambda lobby: lobby.remove(ctx.author))
 
     @commands.command()
     async def remove(self, ctx, member: discord.Member):
-        await self.getLobbyThen(ctx, lambda lobby: lobby.remove(member))
-
+        await self.getLobbyThen(ctx, lambda lobby: lobby.remove(member, author=ctx.author))
+    
     @commands.command()
     async def ready(self, ctx):
         await self.getLobbyThen(ctx, lambda lobby: lobby.ready(ctx.author))


### PR DESCRIPTION
Sometimes we know people intend to play but haven't joined yet. This command `?add` allows you to @tag people and add them to the lobby. This will be useful for starting shuffles in the mentioned circumstance.

I have also anticipated griefers continuously re-adding people. I don't suspect any of us would do this, but I still built in some protections. 
- If the player leaves on their own, they cannot be added by others until the lobby resets.
- If the player is removed by another player, they can still be added by others. 
- The player is always able to join and leave without additional restrictions.  

![test-cant-grief](https://user-images.githubusercontent.com/3579057/90326338-0f8aae00-df3c-11ea-8b65-4ec05eaa254a.png)
![test-can-annoy](https://user-images.githubusercontent.com/3579057/90326339-10bbdb00-df3c-11ea-9ebf-b5133302c35d.png)
