### PR TITLE
Create lobby on join or flyin if not already created

### DIFF
--- a/__tests__/test_lobby.py
+++ b/__tests__/test_lobby.py
@@ -53,7 +53,7 @@ async def game_data(_channel) -> GameData:
     return GameData(
         [
             Game(
-                AsyncMock(spec=datetime),
+                datetime.today(),
                 Team([id() for _ in range(4)], randint(1000, 3000)),
                 Team([id() for _ in range(4)], randint(1000, 3000)),
             )

--- a/cogs/lobby_commands.py
+++ b/cogs/lobby_commands.py
@@ -44,6 +44,13 @@ class LobbyCommands(Cog):
             "You haven't started a lobby. Use `?start` to open a new lobby."
         )
 
+    async def get_or_create_lobby_then(self, ctx: Context, do_command) -> None:
+        if ctx.channel.id not in self.lobbies:
+            self.lobbies[ctx.channel.id] = Lobby(self.bot, ctx.channel)
+            await ctx.send("The lobby has been started!")
+        self.lobbies[ctx.channel.id].channel = ctx.channel
+        return await do_command(self.lobbies[ctx.channel.id])
+
     # -------- Commands --------
 
     @command()
@@ -80,7 +87,9 @@ class LobbyCommands(Cog):
 
     @command()
     async def join(self, ctx: Context):
-        await self.get_lobby_then(ctx, lambda lobby: lobby.add(ctx.author))
+        await self.get_or_create_lobby_then(
+            ctx, lambda lobby: lobby.add(ctx.author)
+        )
 
     @command()
     async def add(self, ctx, member: Member):
@@ -108,7 +117,9 @@ class LobbyCommands(Cog):
 
     @command()
     async def flyin(self, ctx):
-        await self.get_lobby_then(ctx, lambda lobby: lobby.flyin(ctx.author))
+        await self.get_or_create_lobby_then(
+            ctx, lambda lobby: lobby.flyin(ctx.author)
+        )
 
     @command()
     async def numbers(self, ctx: Context):


### PR DESCRIPTION
Added `get_or_create_lobby_then` to return existing lobby or automatically create a new one if it doesn't exist. ?join and ?flyin will use this instead of `get_lobby_then` so users don't have to use ?start first.