### PR TITLE
Make Lobby Name Embed Author

### DIFF
--- a/__tests__/test_lobby.py
+++ b/__tests__/test_lobby.py
@@ -140,13 +140,13 @@ class TestLobby(AsyncTestCase):
         """
         lobby = Lobby(bot(), channel(topic=topic))
         embed = lobby.get_lobby_message()
-        assert embed.title == "foo Lobby: (0)"
+        assert embed.title == "foo (0)"
         assert embed.footer.text == "More players can join."
         assert embed.colour == Colour.orange()
 
         await lobby.add(player := member())
         embed = lobby.get_lobby_message()
-        assert embed.title == "foo Lobby: (1)"
+        assert embed.title == "foo (1)"
         assert embed.footer.text == "More players can join."
         assert embed.colour == Colour.orange()
         assert len(embed.fields) == 1
@@ -159,7 +159,7 @@ class TestLobby(AsyncTestCase):
 
         await lobby.ready(player)
         embed = lobby.get_lobby_message()
-        assert embed.title == "foo Lobby: (1)"
+        assert embed.title == "foo (1)"
         assert embed.footer.text == "More players can join."
         assert embed.colour == Colour.orange()
         assert len(embed.fields) == 1
@@ -173,7 +173,7 @@ class TestLobby(AsyncTestCase):
         for _ in range(7):
             await lobby.ready(member())
         embed = lobby.get_lobby_message()
-        assert embed.title == "foo Lobby: (8)"
+        assert embed.title == "foo (8)"
         assert embed.footer.text == "Game ready. More players can join."
         assert embed.colour == Colour.green()
         assert len(embed.fields) == 1
@@ -182,7 +182,7 @@ class TestLobby(AsyncTestCase):
 
         await lobby.unready(player)
         embed = lobby.get_lobby_message()
-        assert embed.title == "foo Lobby: (8)"
+        assert embed.title == "foo (8)"
         assert embed.footer.text == "More players can join."
         assert embed.colour == Colour.orange()
         assert len(embed.fields) == 2
@@ -193,7 +193,7 @@ class TestLobby(AsyncTestCase):
 
         await lobby.remove(player)
         embed = lobby.get_lobby_message()
-        assert embed.title == "foo Lobby: (7)"
+        assert embed.title == "foo (7)"
         assert embed.footer.text == "More players can join."
         assert embed.colour == Colour.orange()
         assert len(embed.fields) == 1
@@ -203,7 +203,7 @@ class TestLobby(AsyncTestCase):
         for _ in range(100):
             await lobby.add(member())
         embed = lobby.get_lobby_message()
-        assert embed.title == "foo Lobby: (107)"
+        assert embed.title == "foo (107)"
         assert embed.footer.text == "More players can join."
         assert embed.colour == Colour.orange()
         assert len(embed.fields) == 2
@@ -212,7 +212,7 @@ class TestLobby(AsyncTestCase):
 
         await lobby.ready(member())
         embed = lobby.get_lobby_message()
-        assert embed.title == "foo Lobby: (108)"
+        assert embed.title == "foo (108)"
         assert embed.footer.text == "Game ready. More players can join."
         assert embed.colour == Colour.green()
         assert len(embed.fields) == 2

--- a/models/lobby.py
+++ b/models/lobby.py
@@ -206,11 +206,14 @@ class Lobby:
         if title:
             embed.title = title
         else:
-            subtitle = subtitle or f"({len(self.players)})"
-            embed.title = f"{self.c.vName} Lobby: {subtitle}"
+            lobby_name = f"{self.c.vName} ({len(self.players)})"
+            if subtitle:
+                embed.set_author(name=lobby_name)
+                embed.title = subtitle
+            else:
+                embed.title = lobby_name
 
         ready, alternates = self.get_players()
-
         if ready:
             print = "get_mention" if mention else "get_name"
             value = "".join([f"• {(getattr(p, print))()}\n" for p in ready])


### PR DESCRIPTION
This is clearer than concatenating lobby name and title.
![image](https://user-images.githubusercontent.com/3579057/106718833-6ea9b100-65b6-11eb-9227-45ef3b25f7e3.png)
![image](https://user-images.githubusercontent.com/3579057/106718847-7406fb80-65b6-11eb-910e-e5b48de9f1fc.png)
![image](https://user-images.githubusercontent.com/3579057/106718875-7b2e0980-65b6-11eb-8ffc-f32fa3da3e2e.png)
![image](https://user-images.githubusercontent.com/3579057/106718907-85e89e80-65b6-11eb-816d-6dc702bf7050.png)
